### PR TITLE
feat: process supported ALTER COLUMN operations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,9 @@
 -------------------
 
 - Fix SQLAlchemy V2 support (https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/293)
+- Add Alembic support with Redshift-aware ALTER COLUMN handling. VARCHAR size changes
+  are supported natively; other type changes raise CommandError immediately with detailed
+  migration instructions to prevent invalid SQL generation
 
 
 0.8.14 (2023-04-07)

--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,19 @@ See the `RedshiftDDLCompiler documentation
 <https://sqlalchemy-redshift.readthedocs.org/en/latest/ddl-compiler.html>`_
 for details on Redshift-specific features the dialect supports.
 
+Alembic Support
+---------------
+The dialect supports `Alembic <https://alembic.sqlalchemy.org/>`_ for database
+migrations. Note that Redshift has limited support for ALTER COLUMN operations:
+
+* **Supported**: VARCHAR size changes
+* **Not supported**: Arbitrary type changes (e.g., VARCHAR to INTEGER)
+
+For unsupported operations, the dialect will raise an error immediately with
+detailed instructions for manual migration. See the `Alembic documentation
+<https://sqlalchemy-redshift.readthedocs.org/en/latest/alembic.html>`_ for
+complete details and examples.
+
 Running Tests
 -------------
 Tests are ran via tox and can be run with the following command::

--- a/docs/alembic.rst
+++ b/docs/alembic.rst
@@ -64,7 +64,7 @@ Not Supported:
 
 .. code-block:: python
 
-    # This will generate a warning and fail at runtime
+    # This will raise alembic.util.CommandError immediately
     op.alter_column('users', 'age',
                    type_=sa.Integer(),
                    existing_type=sa.VARCHAR(10))
@@ -73,7 +73,7 @@ Not Supported:
 
 .. code-block:: python
 
-    # This will generate a warning - USING is not supported in Redshift
+    # This will raise alembic.util.CommandError - USING is not supported in Redshift
     op.alter_column('users', 'age',
                    type_=sa.Integer(),
                    existing_type=sa.VARCHAR(10),
@@ -81,9 +81,9 @@ Not Supported:
 
 When you attempt unsupported operations, the dialect will:
 
-1. Generate a Python warning with instructions for manual migration
-2. Still generate the SQL (which will fail at runtime)
-3. Allow the migration file to be created for documentation purposes
+1. **Raise a CommandError immediately** with detailed migration instructions
+2. **Prevent invalid migrations from being generated**
+3. **Provide working example code** for the manual migration approach
 
 Manual Type Change Workaround
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/alembic.rst
+++ b/docs/alembic.rst
@@ -1,0 +1,162 @@
+Alembic Support
+===============
+
+The sqlalchemy-redshift dialect provides support for `Alembic <https://alembic.sqlalchemy.org/>`_ migrations with awareness of Redshift's limitations compared to PostgreSQL.
+
+Basic Usage
+-----------
+
+To use Alembic with Redshift, configure your ``alembic.ini`` with a Redshift connection string:
+
+.. code-block:: ini
+
+    sqlalchemy.url = redshift+psycopg2://user:password@host:5439/database
+
+Or for redshift_connector:
+
+.. code-block:: ini
+
+    sqlalchemy.url = redshift+redshift_connector://user:password@host:5439/database
+
+Supported Operations
+--------------------
+
+The following Alembic operations are fully supported:
+
+* ``create_table()`` - Create new tables
+* ``drop_table()`` - Drop tables
+* ``add_column()`` - Add columns to tables
+* ``drop_column()`` - Remove columns from tables
+* ``rename_table()`` - Rename tables (via ``ALTER TABLE ... RENAME TO``)
+* ``alter_column()`` with ``new_column_name`` - Rename columns
+* ``alter_column()`` with ``type_=VARCHAR(n)`` - Resize VARCHAR columns (Redshift native support)
+
+Limited Support Operations
+--------------------------
+
+ALTER COLUMN TYPE Limitations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Redshift has severe limitations on column type changes compared to PostgreSQL.**
+
+Supported:
+~~~~~~~~~~
+
+* **VARCHAR size changes only**:
+
+.. code-block:: python
+
+    # This works - Redshift supports VARCHAR resizing
+    op.alter_column('users', 'username',
+                   type_=sa.VARCHAR(200),
+                   existing_type=sa.VARCHAR(100))
+
+Generates:
+
+.. code-block:: sql
+
+    ALTER TABLE users ALTER COLUMN username TYPE VARCHAR(200);
+
+Not Supported:
+~~~~~~~~~~~~~~
+
+* **Arbitrary type changes** (e.g., VARCHAR to INTEGER, INTEGER to BIGINT):
+
+.. code-block:: python
+
+    # This will generate a warning and fail at runtime
+    op.alter_column('users', 'age',
+                   type_=sa.Integer(),
+                   existing_type=sa.VARCHAR(10))
+
+* **USING clauses** for type conversion:
+
+.. code-block:: python
+
+    # This will generate a warning - USING is not supported in Redshift
+    op.alter_column('users', 'age',
+                   type_=sa.Integer(),
+                   existing_type=sa.VARCHAR(10),
+                   postgresql_using='age::integer')
+
+When you attempt unsupported operations, the dialect will:
+
+1. Generate a Python warning with instructions for manual migration
+2. Still generate the SQL (which will fail at runtime)
+3. Allow the migration file to be created for documentation purposes
+
+Manual Type Change Workaround
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For non-VARCHAR type changes, you must manually perform a multi-step migration:
+
+.. code-block:: python
+
+    def upgrade():
+        # Step 1: Add new column with desired type
+        op.add_column('users', sa.Column('age_new', sa.Integer(), nullable=True))
+        
+        # Step 2: Copy and cast data from old column to new column
+        op.execute('UPDATE users SET age_new = age::integer')
+        
+        # Step 3: Drop the old column
+        op.drop_column('users', 'age')
+        
+        # Step 4: Rename new column to original name
+        op.alter_column('users', 'age_new', new_column_name='age')
+
+    def downgrade():
+        # Reverse the process
+        op.add_column('users', sa.Column('age_new', sa.VARCHAR(10), nullable=True))
+        op.execute('UPDATE users SET age_new = age::varchar(10)')
+        op.drop_column('users', 'age')
+        op.alter_column('users', 'age_new', new_column_name='age')
+
+Other Limitations
+-----------------
+
+Redshift does not support the following PostgreSQL features:
+
+* ``SET DEFAULT`` / ``DROP DEFAULT`` via ``ALTER COLUMN`` (add defaults during ``ADD COLUMN`` instead)
+* ``SET NOT NULL`` / ``DROP NOT NULL`` via ``ALTER COLUMN`` (define constraints during ``ADD COLUMN`` instead)
+* Check constraints (can be defined but not enforced)
+* Foreign key constraints (can be defined but not enforced)
+* Most PostgreSQL-specific types and features
+
+Redshift Extensions
+-------------------
+
+The dialect supports Redshift-specific table options via dialect-specific arguments:
+
+.. code-block:: python
+
+    def upgrade():
+        op.create_table(
+            'events',
+            sa.Column('id', sa.Integer(), primary_key=True),
+            sa.Column('user_id', sa.Integer()),
+            sa.Column('event_time', sa.TIMESTAMP()),
+            sa.Column('event_data', sa.VARCHAR(1000)),
+            redshift_diststyle='KEY',
+            redshift_distkey='user_id',
+            redshift_sortkey=['event_time', 'user_id']
+        )
+
+See the :doc:`ddl-compiler` documentation for more details on Redshift-specific table options.
+
+Best Practices
+--------------
+
+1. **Test migrations in a development environment** before applying to production
+2. **Use VARCHAR size changes** when possible instead of full type changes
+3. **Plan manual migrations** for complex type changes
+4. **Review generated SQL** for unsupported operations
+5. **Consider the data volume** when planning manual type changes (they require a full table copy)
+6. **Use Redshift-specific features** like distribution keys and sort keys for better performance
+
+Additional Resources
+--------------------
+
+* `Amazon Redshift ALTER TABLE documentation <https://docs.aws.amazon.com/redshift/latest/dg/r_ALTER_TABLE.html>`_
+* `Alembic documentation <https://alembic.sqlalchemy.org/>`_
+* `SQLAlchemy documentation <https://docs.sqlalchemy.org/>`_

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,7 @@ Contents:
    ddl-compiler
    dialect
    commands
+   alembic
 
 Indices and tables
 ==================

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -50,8 +50,124 @@ else:
         from alembic.ddl.base import ColumnComment
         compiles(ColumnComment, 'redshift')(postgresql.visit_column_comment)
 
+    if Version(alembic.__version__) >= Version('0.6.0'):
+        from alembic.ddl.postgresql import PostgresqlColumnType
+
+        @compiles(PostgresqlColumnType, 'redshift')
+        def visit_redshift_column_type(
+            element: 'PostgresqlColumnType', compiler: 'PGDDLCompiler', **kw
+        ) -> str:
+            """
+            Redshift-specific implementation for column type changes.
+
+            Redshift has severe limitations on ALTER COLUMN TYPE:
+            - Only VARCHAR size changes are supported
+            - No arbitrary type changes (e.g., VARCHAR to INTEGER)
+            - No USING clause support
+
+            For VARCHAR size changes only, we use the native Redshift syntax.
+            For other type changes, this will generate the SQL but it will
+            fail at runtime - users must handle type changes manually via:
+            1. ADD new column with new type
+            2. UPDATE to copy/cast data
+            3. DROP old column
+            4. RENAME new column to old name
+            """
+            from sqlalchemy.dialects.postgresql import VARCHAR
+
+            # Check if this is a VARCHAR-to-VARCHAR size change (supported by Redshift)
+            is_varchar_resize = (
+                isinstance(element.type_, VARCHAR) and
+                element.using is None
+            )
+
+            if is_varchar_resize:
+                # Use Redshift's limited ALTER COLUMN TYPE syntax (VARCHAR size only)
+                return "%s %s %s" % (
+                    postgresql.alter_table(compiler, element.table_name, element.schema),
+                    postgresql.alter_column(compiler, element.column_name),
+                    "TYPE %s" % postgresql.format_type(compiler, element.type_),
+                )
+            else:
+                # For non-VARCHAR type changes or USING clauses, generate a warning comment
+                # The SQL will be generated but won't work in Redshift
+                import warnings
+                warnings.warn(
+                    f"Redshift does not support ALTER COLUMN TYPE for changing "
+                    f"'{element.column_name}' to {element.type_}. "
+                    f"This operation requires manual migration: "
+                    f"(1) ADD new column, (2) UPDATE/copy data, (3) DROP old column, "
+                    f"(4) RENAME new column.",
+                    UserWarning
+                )
+                # Generate PostgreSQL-style SQL anyway (will fail at runtime)
+                # This allows the migration to be generated for documentation
+                return postgresql.visit_column_type(element, compiler, **kw)
+
     class RedshiftImpl(postgresql.PostgresqlImpl):
         __dialect__ = 'redshift'
+
+        def alter_column(self, table_name, column_name,
+                        nullable=None, server_default=False, name=None,
+                        type_=None, schema=None, autoincrement=None,
+                        existing_type=None, existing_server_default=None,
+                        existing_nullable=None, existing_autoincrement=None,
+                        **kw):
+            """
+            Override alter_column to handle Redshift's limitations.
+
+            Redshift only supports:
+            - VARCHAR size changes (ALTER COLUMN ... TYPE VARCHAR(n))
+            - Column encoding changes (ALTER COLUMN ... ENCODE)
+            - NOT NULL constraints (but not via ALTER COLUMN)
+
+            Redshift does NOT support:
+            - Arbitrary type changes (e.g., INTEGER to VARCHAR)
+            - USING clauses
+            - Changing column defaults (use ADD DEFAULT/DROP DEFAULT separately)
+            """
+            from sqlalchemy.dialects.postgresql import VARCHAR
+            import warnings
+
+            # Check if attempting unsupported type change
+            if type_ is not None and not isinstance(type_, VARCHAR):
+                warnings.warn(
+                    f"Redshift does not support ALTER COLUMN TYPE for changing "
+                    f"column '{column_name}' from {existing_type} to {type_}. "
+                    f"Only VARCHAR size changes are supported. "
+                    f"For other type changes, you must manually: "
+                    f"(1) ADD a new column with the desired type, "
+                    f"(2) UPDATE to copy/cast data from old to new column, "
+                    f"(3) DROP the old column, "
+                    f"(4) RENAME the new column to the original name.",
+                    UserWarning,
+                    stacklevel=3
+                )
+
+            # Check for postgresql_using parameter (not supported in Redshift)
+            if kw.get('postgresql_using'):
+                warnings.warn(
+                    "Redshift does not support USING clauses in ALTER COLUMN. "
+                    "The 'postgresql_using' parameter will be ignored.",
+                    UserWarning,
+                    stacklevel=3
+                )
+
+            # Call parent implementation
+            super(RedshiftImpl, self).alter_column(
+                table_name, column_name,
+                nullable=nullable,
+                server_default=server_default,
+                name=name,
+                type_=type_,
+                schema=schema,
+                autoincrement=autoincrement,
+                existing_type=existing_type,
+                existing_server_default=existing_server_default,
+                existing_nullable=existing_nullable,
+                existing_autoincrement=existing_autoincrement,
+                **kw
+            )
 
 # "Each dialect provides the full set of typenames supported by that backend
 # with its __all__ collection
@@ -1754,7 +1870,7 @@ def visit_delete_stmt(element, compiler, **kwargs):
 
     # determine if the delete query needs a ``USING`` injected
     # by inspecting the whereclause's children & their children...
-    # first, the where clause text is buit, if applicable
+    # first, the where clause text is built, if applicable
     # then, the using clause text is built, if applicable
     # note:
     #   the tables in the using clause are sorted in the order in

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -89,20 +89,33 @@ else:
                     "TYPE %s" % postgresql.format_type(compiler, element.type_),
                 )
             else:
-                # For non-VARCHAR type changes or USING clauses, generate a warning comment
-                # The SQL will be generated but won't work in Redshift
-                import warnings
-                warnings.warn(
+                # For non-VARCHAR type changes or USING clauses, raise an exception
+                from sqlalchemy.exc import CompileError
+
+                error_msg = (
                     f"Redshift does not support ALTER COLUMN TYPE for changing "
-                    f"'{element.column_name}' to {element.type_}. "
-                    f"This operation requires manual migration: "
-                    f"(1) ADD new column, (2) UPDATE/copy data, (3) DROP old column, "
-                    f"(4) RENAME new column.",
-                    UserWarning
+                    f"column '{element.column_name}' to {element.type_}."
                 )
-                # Generate PostgreSQL-style SQL anyway (will fail at runtime)
-                # This allows the migration to be generated for documentation
-                return postgresql.visit_column_type(element, compiler, **kw)
+
+                if element.using:
+                    error_msg += "\nRedshift does not support USING clauses in ALTER COLUMN."
+
+                error_msg += (
+                    "\n\nOnly VARCHAR size changes are supported via ALTER COLUMN TYPE."
+                    "\n\nTo change column types in Redshift, you must manually perform a multi-step migration:"
+                    "\n  1. ADD a new column with the desired type"
+                    "\n  2. UPDATE to copy/cast data from old column to new column"
+                    "\n  3. DROP the old column"
+                    "\n  4. RENAME the new column to the original name"
+                    "\n\nExample migration:"
+                    f"\n  op.add_column('{element.table_name}', sa.Column('{element.column_name}_new', {element.type_!r}))"
+                    f"\n  op.execute('UPDATE {element.table_name} SET {element.column_name}_new = {element.column_name}::{element.type_}')"
+                    f"\n  op.drop_column('{element.table_name}', '{element.column_name}')"
+                    f"\n  op.alter_column('{element.table_name}', '{element.column_name}_new', new_column_name='{element.column_name}')"
+                    "\n\nFor more information, see: https://docs.aws.amazon.com/redshift/latest/dg/r_ALTER_TABLE.html"
+                )
+
+                raise CompileError(error_msg)
 
     class RedshiftImpl(postgresql.PostgresqlImpl):
         __dialect__ = 'redshift'
@@ -127,31 +140,35 @@ else:
             - Changing column defaults (use ADD DEFAULT/DROP DEFAULT separately)
             """
             from sqlalchemy.dialects.postgresql import VARCHAR
-            import warnings
+            from alembic.util import CommandError
 
             # Check if attempting unsupported type change
             if type_ is not None and not isinstance(type_, VARCHAR):
-                warnings.warn(
+                error_msg = (
                     f"Redshift does not support ALTER COLUMN TYPE for changing "
                     f"column '{column_name}' from {existing_type} to {type_}. "
-                    f"Only VARCHAR size changes are supported. "
-                    f"For other type changes, you must manually: "
-                    f"(1) ADD a new column with the desired type, "
-                    f"(2) UPDATE to copy/cast data from old to new column, "
-                    f"(3) DROP the old column, "
-                    f"(4) RENAME the new column to the original name.",
-                    UserWarning,
-                    stacklevel=3
+                    f"Only VARCHAR size changes are supported."
+                    f"\n\nTo change column types in Redshift, you must manually perform a multi-step migration:"
+                    f"\n  1. ADD a new column with the desired type"
+                    f"\n  2. UPDATE to copy/cast data from old to new column"
+                    f"\n  3. DROP the old column"
+                    f"\n  4. RENAME the new column to the original name"
+                    f"\n\nExample:"
+                    f"\n  op.add_column('{table_name}', sa.Column('{column_name}_new', {type_!r}))"
+                    f"\n  op.execute('UPDATE {table_name} SET {column_name}_new = {column_name}::{type_}')"
+                    f"\n  op.drop_column('{table_name}', '{column_name}')"
+                    f"\n  op.alter_column('{table_name}', '{column_name}_new', new_column_name='{column_name}')"
                 )
+                raise CommandError(error_msg)
 
             # Check for postgresql_using parameter (not supported in Redshift)
             if kw.get('postgresql_using'):
-                warnings.warn(
+                error_msg = (
                     "Redshift does not support USING clauses in ALTER COLUMN. "
-                    "The 'postgresql_using' parameter will be ignored.",
-                    UserWarning,
-                    stacklevel=3
+                    "The 'postgresql_using' parameter cannot be used with Redshift."
+                    "\n\nYou must manually perform the type conversion in your migration using UPDATE statements."
                 )
+                raise CommandError(error_msg)
 
             # Call parent implementation
             super(RedshiftImpl, self).alter_column(

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -65,13 +65,12 @@ else:
             - No arbitrary type changes (e.g., VARCHAR to INTEGER)
             - No USING clause support
 
-            For VARCHAR size changes only, we use the native Redshift syntax.
-            For other type changes, this will generate the SQL but it will
-            fail at runtime - users must handle type changes manually via:
-            1. ADD new column with new type
-            2. UPDATE to copy/cast data
-            3. DROP old column
-            4. RENAME new column to old name
+            For VARCHAR size changes without USING clauses, we generate valid
+            Redshift SQL. For all other operations, we raise a CompileError
+            immediately with detailed instructions for manual migration.
+
+            This fail-fast approach prevents invalid migrations from being
+            generated and provides clear guidance to developers.
             """
             from sqlalchemy.dialects.postgresql import VARCHAR
 
@@ -82,14 +81,14 @@ else:
             )
 
             if is_varchar_resize:
-                # Use Redshift's limited ALTER COLUMN TYPE syntax (VARCHAR size only)
+                # Generate valid Redshift ALTER COLUMN TYPE syntax (VARCHAR size changes only)
                 return "%s %s %s" % (
                     postgresql.alter_table(compiler, element.table_name, element.schema),
                     postgresql.alter_column(compiler, element.column_name),
                     "TYPE %s" % postgresql.format_type(compiler, element.type_),
                 )
             else:
-                # For non-VARCHAR type changes or USING clauses, raise an exception
+                # Fail fast with detailed migration instructions for unsupported operations
                 from sqlalchemy.exc import CompileError
 
                 error_msg = (
@@ -138,6 +137,10 @@ else:
             - Arbitrary type changes (e.g., INTEGER to VARCHAR)
             - USING clauses
             - Changing column defaults (use ADD DEFAULT/DROP DEFAULT separately)
+
+            This method raises CommandError immediately when unsupported
+            operations are attempted, providing detailed migration instructions
+            for manual workarounds.
             """
             from sqlalchemy.dialects.postgresql import VARCHAR
             from alembic.util import CommandError

--- a/tests/test_alembic_dialect.py
+++ b/tests/test_alembic_dialect.py
@@ -2,7 +2,8 @@ from alembic.ddl.base import RenameTable, ColumnComment
 from alembic.ddl.postgresql import PostgresqlColumnType
 from alembic import migration
 from sqlalchemy import Integer, VARCHAR
-import warnings
+from sqlalchemy.exc import CompileError
+import pytest
 
 from sqlalchemy_redshift import dialect
 
@@ -37,21 +38,21 @@ def test_alter_column_type_varchar_supported(stub_redshift_dialect):
     assert sql == 'ALTER TABLE table_name ALTER COLUMN column_name TYPE VARCHAR(100)'
 
 
-def test_alter_column_type_unsupported_warns(stub_redshift_dialect):
-    """Test non-VARCHAR type change - unsupported by Redshift, should warn"""
+def test_alter_column_type_unsupported_raises(stub_redshift_dialect):
+    """Test non-VARCHAR type change - unsupported by Redshift, should raise exception"""
     compiler = dialect.RedshiftDDLCompiler(stub_redshift_dialect, None)
 
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        sql = compiler.process(
+    with pytest.raises(CompileError) as exc_info:
+        compiler.process(
             PostgresqlColumnType("table_name", "column_name", Integer())
         )
 
-        # Should generate a warning
-        assert len(w) == 1
-        assert "Redshift does not support ALTER COLUMN TYPE" in str(w[0].message)
-        assert "manual migration" in str(w[0].message)
-
-        # Should still generate SQL (for documentation purposes)
-        assert 'ALTER TABLE table_name' in sql
-        assert 'column_name' in sql
+    # Should raise with helpful error message
+    error_msg = str(exc_info.value)
+    assert "Redshift does not support ALTER COLUMN TYPE" in error_msg
+    assert "Only VARCHAR size changes are supported" in error_msg
+    assert "multi-step migration" in error_msg
+    assert "op.add_column" in error_msg
+    assert "op.execute" in error_msg
+    assert "op.drop_column" in error_msg
+    assert "op.alter_column" in error_msg

--- a/tests/test_alembic_dialect.py
+++ b/tests/test_alembic_dialect.py
@@ -30,7 +30,10 @@ def test_alter_column_comment(stub_redshift_dialect):
 
 
 def test_alter_column_type_varchar_supported(stub_redshift_dialect):
-    """Test VARCHAR size change - supported by Redshift"""
+    """
+    Test VARCHAR size change - the only ALTER COLUMN TYPE operation 
+    supported by Redshift. Should generate valid SQL without errors.
+    """
     compiler = dialect.RedshiftDDLCompiler(stub_redshift_dialect, None)
     sql = compiler.process(
         PostgresqlColumnType("table_name", "column_name", VARCHAR(100))
@@ -39,7 +42,13 @@ def test_alter_column_type_varchar_supported(stub_redshift_dialect):
 
 
 def test_alter_column_type_unsupported_raises(stub_redshift_dialect):
-    """Test non-VARCHAR type change - unsupported by Redshift, should raise exception"""
+    """
+    Test non-VARCHAR type change - unsupported by Redshift.
+    
+    Should raise CompileError immediately (fail-fast) with detailed
+    migration instructions rather than generating invalid SQL that
+    would fail at runtime.
+    """
     compiler = dialect.RedshiftDDLCompiler(stub_redshift_dialect, None)
 
     with pytest.raises(CompileError) as exc_info:
@@ -47,7 +56,7 @@ def test_alter_column_type_unsupported_raises(stub_redshift_dialect):
             PostgresqlColumnType("table_name", "column_name", Integer())
         )
 
-    # Should raise with helpful error message
+    # Verify the error message provides actionable guidance
     error_msg = str(exc_info.value)
     assert "Redshift does not support ALTER COLUMN TYPE" in error_msg
     assert "Only VARCHAR size changes are supported" in error_msg

--- a/tests/test_alembic_dialect.py
+++ b/tests/test_alembic_dialect.py
@@ -1,5 +1,8 @@
 from alembic.ddl.base import RenameTable, ColumnComment
+from alembic.ddl.postgresql import PostgresqlColumnType
 from alembic import migration
+from sqlalchemy import Integer, VARCHAR
+import warnings
 
 from sqlalchemy_redshift import dialect
 
@@ -23,3 +26,32 @@ def test_alter_column_comment(stub_redshift_dialect):
         ColumnComment("table_name", "column_name", "my comment")
     )
     assert sql == "COMMENT ON COLUMN table_name.column_name IS 'my comment'"
+
+
+def test_alter_column_type_varchar_supported(stub_redshift_dialect):
+    """Test VARCHAR size change - supported by Redshift"""
+    compiler = dialect.RedshiftDDLCompiler(stub_redshift_dialect, None)
+    sql = compiler.process(
+        PostgresqlColumnType("table_name", "column_name", VARCHAR(100))
+    )
+    assert sql == 'ALTER TABLE table_name ALTER COLUMN column_name TYPE VARCHAR(100)'
+
+
+def test_alter_column_type_unsupported_warns(stub_redshift_dialect):
+    """Test non-VARCHAR type change - unsupported by Redshift, should warn"""
+    compiler = dialect.RedshiftDDLCompiler(stub_redshift_dialect, None)
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        sql = compiler.process(
+            PostgresqlColumnType("table_name", "column_name", Integer())
+        )
+
+        # Should generate a warning
+        assert len(w) == 1
+        assert "Redshift does not support ALTER COLUMN TYPE" in str(w[0].message)
+        assert "manual migration" in str(w[0].message)
+
+        # Should still generate SQL (for documentation purposes)
+        assert 'ALTER TABLE table_name' in sql
+        assert 'column_name' in sql

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,6 @@ deps =
     packaging==20.4
     psycopg2cffi==2.8.1
     pytest==7.2.1
-    requests==2.25.0
     redshift_connector==2.0.907
     requests==2.25.0
 


### PR DESCRIPTION
This change will allow alembic-generated migrations to generate column alters, with warnings if it's not supported by redshift. This will allow for further isolation of issues.

The enterprise-schema migration generation validates that all migrations function correctly, so if an unsupported migration is created, it will fail and not be pushed to the enterprise.